### PR TITLE
Fix link to new HTML location in CCG repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 Deliverables of W3C’s *RDF Dataset Canonicalization* activity under the [Credentials Community Group](https://www.w3.org/community/credentials/). Please consult that page for further details on the goals and deliverables of the that group.
 
-To view (HTML) files can be [read directly](https://json-ld.github.io/rdf-dataset-canonicalization/spec/).
+To view (HTML) files can be [read directly](https://w3c-ccg.github.io/rdf-dataset-canonicalization/spec/).


### PR DESCRIPTION
In addition to this PR, the same link should also be updated in the Github repository description (shown on the right side of the repository index page).